### PR TITLE
Fix Terra and Everflame spell name

### DIFF
--- a/common/src/main/resources/assets/hexgloop/lang/en_us.json
+++ b/common/src/main/resources/assets/hexgloop/lang/en_us.json
@@ -135,8 +135,8 @@
     "hexcasting.spell.hexgloop:clear_truename": "Renew Truename",
     "hexcasting.spell.hexgloop:truename_agree_eula": "Acknowledge Truename",
 
-    "hexcasting.spell.hexgloop:in_overworld": "Terra Reflection",
-    "hexcasting.spell.hexgloop:in_nether": "Everflame Reflection",
+    "hexcasting.spell.hexgloop:in_overworld": "Terra Purifcation",
+    "hexcasting.spell.hexgloop:in_nether": "Everflame Purification",
     "hexcasting.spell.hexgloop:opnop_useless": "Aergia's Gambit",
     "hexcasting.spell.hexgloop:check_ambit": "Canary's Purification",
     "hexcasting.spell.hexgloop:catchy_eval": "Athena's Gambit",

--- a/common/src/main/resources/assets/hexgloop/lang/en_us.json
+++ b/common/src/main/resources/assets/hexgloop/lang/en_us.json
@@ -135,7 +135,7 @@
     "hexcasting.spell.hexgloop:clear_truename": "Renew Truename",
     "hexcasting.spell.hexgloop:truename_agree_eula": "Acknowledge Truename",
 
-    "hexcasting.spell.hexgloop:in_overworld": "Terra Purifcation",
+    "hexcasting.spell.hexgloop:in_overworld": "Terra Purification",
     "hexcasting.spell.hexgloop:in_nether": "Everflame Purification",
     "hexcasting.spell.hexgloop:opnop_useless": "Aergia's Gambit",
     "hexcasting.spell.hexgloop:check_ambit": "Canary's Purification",


### PR DESCRIPTION
Changed both Terra and Everflame Reflection to Purification, The rest of the changes appear to have already been done in the main